### PR TITLE
Return shutdown to the supervisor an terminate reason

### DIFF
--- a/src/wsserver_worker.erl
+++ b/src/wsserver_worker.erl
@@ -93,7 +93,7 @@ evaluate_protocol_response(Response, WorkerState) ->
       noreply;
     {close, Reply} ->
       wsserver_worker_tcp:send(wsserver_worker_state_data:worker_tcp(WorkerState), Reply),
-      {stop, server_connection_close};
+      {stop, shutdown};
     noreply ->
         noreply;
     {stop, Reason} ->


### PR DESCRIPTION
Otherwise the supervisor will consider that the worker crashed